### PR TITLE
add contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# How To Contribute
+In order to contribute to this project, please:
+* Ensure that you have set your `git config --global user.name` and `git config --global user.email` before committing
+* Always use feature branches for anything you contribute (i.e. you shouldn't work on the `master` branch of your own fork)
+* Always write [proper commit messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
+  (also featured in the [Git book](https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project))
+* Always work [in your fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo)
+* Follow the [GitHub flow](https://docs.github.com/en/get-started/quickstart/github-flow)
+* Use [atomic commits](https://www.aleksandrhovhannisyan.com/blog/atomic-git-commits/)
+  * Also follow this with your PRs: if two things are not related they should preferably not be in the same PR so that
+    their reviews can happen in parallel and one doesn't block the other.
+
+## For Code Contributions
+When contributing code (rather than e.g. documentation):
+* Make sure that your code builds
+* Make sure to add test coverage (where reasonably possible)
+* Make sure that it's properly documented (where applicable)
+
+## Useful Resources
+If you're new to Git, GitHub and all of this, these links might help you:
+* [Git](https://git-scm.com/) (official page with downloads, more links, etc.)
+* [Official Git Book](https://git-scm.com/book)
+  * See esp. [chapter 5.2 Distributed Git - Contributing to a Project](https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project)
+* [GitHub Quickstart](https://docs.github.com/en/get-started/quickstart)
+* [GitHub's Git Guide](https://github.com/git-guides)
+* [GitHub's Git Cheat Sheet](https://training.github.com/)
+* [Official Git Reference Manual](https://git-scm.com/docs)
+  * Usually you'll instead get here by just typing `git help` or `git help [command]` rather than searching on the page


### PR DESCRIPTION
this is a first iteration on the contribution guide with relevant links for people who are not yet super familiar with using Git & GitHub.

as this file is named `CONTRIBUTING.md` it'll be picked up by GitHub and shown in the UI in the appropriate places, see [the docs][gh-docs].

[gh-docs]: https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors