### PR TITLE
add GitHub code owner configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# default code owners
+* @rursprung @joel5399 @Prince-Sigvald @TimBarmettler4


### PR DESCRIPTION
this ensures that the right people are added as reviewers to pull requests modifying files in their area.

as we don't have any specific content yet all team members are just added as default reeviewers for everything. when adding more content we can see if it makes sense to specify specific people for certain areas.

see the [documentation][gh-docs] for further details on how this file works.

note: the repository is already configured to require _at least_ one review before a PR can be merged. this file just helps by adding everyone as reviewers to the PRs to make this more obvious (and help in case somebody hasn't set up their notifications to be notified of all PRs happening in the repository).

[gh-docs]: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners