### PR TITLE
properly model dependencies between packages

### DIFF
--- a/smt_launch_gazebo/package.xml
+++ b/smt_launch_gazebo/package.xml
@@ -50,7 +50,7 @@
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>gazebo_ros</depend>
+  <depend>smt_model_description</depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/smt_model_description/package.xml
+++ b/smt_model_description/package.xml
@@ -42,6 +42,8 @@
   <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>gazebo_ros</depend>
+
   <!-- The export tag contains other, unspecified, tags -->
   <export>
     <!-- Other tools can request additional information be placed here -->


### PR DESCRIPTION
`smt_launch_gazebo` doesn't depend directly on gazebo anymore, instead it includes the launch file from `smt_model_description` which then launches gazebo.

this is relevant when using `rosdep install --from-paths .` (though it won't be able to download our packages if they were missing as they aren't published, but it'd complain if one of them were forgotten from the workspace), the error will then look like this:
```
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
smt_launch_gazebo: Cannot locate rosdep definition for [smt_model_description]
```