### PR TITLE
Add camera link optical

### DIFF
--- a/smt_model_description/urdf/smt_model.gazebo
+++ b/smt_model_description/urdf/smt_model.gazebo
@@ -134,7 +134,7 @@
         <cameraName>camera1</cameraName>
         <imageTopicName>image_raw</imageTopicName>
         <cameraInfoTopicName>camera_info</cameraInfoTopicName>
-        <frameName>camera_link</frameName>
+        <frameName>camera_link_optical</frameName>
         <hackBaseline>0.07</hackBaseline>
         <distortionK1>0.0</distortionK1>
         <distortionK2>0.0</distortionK2>

--- a/smt_model_description/urdf/smt_model.xacro
+++ b/smt_model_description/urdf/smt_model.xacro
@@ -191,4 +191,12 @@
     <child link="cam_1"/>
   </joint>
 
+  <joint name="camera_optical_joint" type="fixed">
+    <origin xyz="0 0 0" rpy="-1.5708 0 -1.5708"/>
+    <parent link="cam_1"/>
+    <child link="camera_link_optical"/>
+  </joint>
+
+  <link name="camera_link_optical" />
+
 </robot>


### PR DESCRIPTION
I just realized, that Gazebo uses the standard coordinate system with x forward, while most image processing software (including OpenCV) use the standard where x is to the right, y is down, and z is forward. Therefore, I corrected this in the simulation and added a new link (camera_link_optical) and linked it.