### PR TITLE
add `rplidar_ros` for HW launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,22 @@ Follow the guide above to set up your repository and then:
 5. Follow [the contribution guide](CONTRIBUTING.md) for further details.
 
 ### Running The Code
+#### Simulation
 After building the project you can run the simulated robot using:
 ```bash
 roslaunch smt_launch_gazebo default.launch
 ```
 
 You can use the arrow keys to navigate in the world.
+
+#### On the Robot
+To run the code on the robot you initially need to set up the udev rules for the LIDAR:
+```bash
+$(rospack find rplidar_ros)/scripts/create_udev_rules.sh
+```
+This only needs to be done once.
+
+Afterward you can launch the on the robot:
+```bash
+roslaunch smt_launch_hardware default.launch
+```

--- a/smt_launch_hardware/launch/default.launch
+++ b/smt_launch_hardware/launch/default.launch
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <launch>
+  <include file="$(find rplidar_ros)/launch/rplidar.launch"/>
+
   <include file="$(find smt_camera_controller)/launch/camera_controller.launch"/>
   <include file="$(find smt_movement_controller)/launch/movement_controller.launch"/>
 </launch>

--- a/smt_launch_hardware/package.xml
+++ b/smt_launch_hardware/package.xml
@@ -52,7 +52,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <depend>smt_camera_controller</depend>
   <depend>smt_movement_controller</depend>
-
+  <exec_depend>rplidar_ros</exec_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
the [`rplidar_ros`] package is used to read the data from the physical LIDAR and create ROS messages out of it. this package is provided by the manufacturer of the LIDAR.

note that after this commit you need to run
```bash
rosdep install --from-paths . -i
```
again. and on RPi used on the robot you once need to run the script to set up the new udev rules (after `rosdep install` as it needs `rplidar_ros` to be present):
```bash
$(rospack find rplidar_ros)/scripts/create_udev_rules.sh
```

[`rplidar_ros`]: https://wiki.ros.org/rplidar