### PR TITLE
HW launch: use `lidar_1` as `frame_id`

### DIFF
--- a/smt_launch_hardware/launch/default.launch
+++ b/smt_launch_hardware/launch/default.launch
@@ -1,6 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <launch>
-  <include file="$(find rplidar_ros)/launch/rplidar.launch"/>
+  <node name="rplidarNode" pkg="rplidar_ros" type="rplidarNode" output="screen">
+    <param name="serial_port" type="string" value="/dev/ttyUSB0"/>
+    <param name="serial_baudrate" type="int" value="115200"/>
+    <param name="frame_id" type="string" value="lidar_1"/>
+    <param name="inverted" type="bool" value="false"/>
+    <param name="angle_compensate" type="bool" value="true"/>
+  </node>
 
   <include file="$(find smt_camera_controller)/launch/camera_controller.launch"/>
   <include file="$(find smt_movement_controller)/launch/movement_controller.launch"/>


### PR DESCRIPTION
by default the `rplidar.launch` sets the `frame_id` to `laser`, which is different from what we've set in our model and what we use in our configuration. accordingly, the mapping algorithm so far failed to properly handle the laser scan messages.

as `rplidar.launch` doesn't expose this as an argument i instead just copied over the whole node launch code and adjusted this one line.