### PR TITLE
rewrite `pigpio` code to `pigpiod_if2`

### DIFF
--- a/smt_movement_controller/cmake/Findpigpio.cmake
+++ b/smt_movement_controller/cmake/Findpigpio.cmake
@@ -8,6 +8,6 @@ ExternalProject_Add(pigpio
 ExternalProject_Get_Property(pigpio INSTALL_DIR)
 
 set(pigpio_INCLUDE_DIR ${INSTALL_DIR}/include)
-set(pigpio_LIBRARIES ${INSTALL_DIR}/lib/libpigpio.so)
+set(pigpio_LIBRARIES ${INSTALL_DIR}/lib/libpigpio.so ${INSTALL_DIR}/lib/libpigpiod_if2.so)
 
 mark_as_advanced(pigpio_INCLUDE_DIR pigpio_LIBRARIES)

--- a/smt_movement_controller/include/smt_movement_controller/gpio_controller.hpp
+++ b/smt_movement_controller/include/smt_movement_controller/gpio_controller.hpp
@@ -4,8 +4,15 @@
 namespace smt {
     namespace gpio_controller {
 
-        void initPi();
-        void applyMotorSpeed(const double vLeft, const double vRight);
+        class GpioController {
+        public:
+            GpioController();
+            ~GpioController();
+            void applyMotorSpeed(const double vLeft, const double vRight) const;
+
+        private:
+            int pi; //< the ID returned by pigpio_start
+        };
 
     }  // namespace gpio_controller
 }  // namespace smt

--- a/smt_movement_controller/include/smt_movement_controller/movement_controller.hpp
+++ b/smt_movement_controller/include/smt_movement_controller/movement_controller.hpp
@@ -4,6 +4,8 @@
 #include <geometry_msgs/Twist.h>
 #include <ros/ros.h>
 
+#include "smt_movement_controller/gpio_controller.hpp"
+
 namespace smt {
 
     namespace movement_controller {
@@ -11,13 +13,12 @@ namespace smt {
         class MovementController {
         public:
             MovementController(ros::NodeHandle& nodeHandle);
-            ~MovementController();
             void velocityCommandCallback(const geometry_msgs::Twist::ConstPtr& velocity) const;
             std::pair<double, double> mapRobotVelocityToMotorSpeed(const double& linear_speed, const double& angular_speed) const;
 
         private:
             ros::Subscriber velSubscriber;
-
+            gpio_controller::GpioController gpioController;
         };
     }  // namespace movement_controller
 

--- a/smt_movement_controller/launch/movement_controller.launch
+++ b/smt_movement_controller/launch/movement_controller.launch
@@ -1,8 +1,7 @@
 <?xml version="1.0"?>
 
 <launch>   
-  
-    <node name="smt_movement_controller" pkg="smt_movement_controller" type="node" output="screen" launch-prefix="sudo">
+    <node name="smt_movement_controller" pkg="smt_movement_controller" type="node" output="screen">
         <rosparam file="$(find smt_movement_controller)/config/default.yaml" command="load"/>
     </node>
 </launch>

--- a/smt_movement_controller/src/movement_controller.cpp
+++ b/smt_movement_controller/src/movement_controller.cpp
@@ -22,17 +22,12 @@ namespace smt {
             velSubscriber = nodeHandle.subscribe(velTopic, subscriberQueueSize, &MovementController::velocityCommandCallback, this);
             ROS_INFO("starting subscriber for %s with queue size %i", velTopic.c_str(), subscriberQueueSize);
 
-            smt::gpio_controller::initPi();
             ROS_INFO("init done");
-        }
-
-        MovementController::~MovementController() {
-            gpioTerminate();
         }
 
         void MovementController::velocityCommandCallback(const geometry_msgs::Twist::ConstPtr& velocity) const {
             std::pair<double, double> leftAndRightSpeed = mapRobotVelocityToMotorSpeed(velocity->linear.x, velocity->angular.z);
-            smt::gpio_controller::applyMotorSpeed(leftAndRightSpeed.first, leftAndRightSpeed.second);
+            this->gpioController.applyMotorSpeed(leftAndRightSpeed.first, leftAndRightSpeed.second);
         }
 
         std::pair<double, double> MovementController::mapRobotVelocityToMotorSpeed(const double& linear_speed, const double& angular_speed) const {


### PR DESCRIPTION
we currently start a `pigpiod` as part of our own process. this has
several drawbacks:
* "there can be only one!": we cannot have two packages interacting with
  the GPIO pins separately (e.g. one the movement & gun controllers)
* there's already a `pigpiod` running on the default port 8888, so we
  currently have to manually set ours to 8889
* if our application doesn't terminate properly we have to kill it
  manually to be able to start it again
* we need to launch our node which uses `pigpio` with `sudo` for it to
  work

instead of using our current approach with [the C interface][pigpio-cif]
we can use [pigpiod_if2]. this is an API which connects to an already
running deamon (and in our case it's always already running as it's
started as a service) and sends the commands there.
this allows us to start an arbitrary amount of nodes which talk to the
GPIO pins and they don't need `sudo` rights.

[pigpio-cif]: https://abyz.me.uk/rpi/pigpio/cif.html
[pigpiod_if2]: http://abyz.me.uk/rpi/pigpio/pdif2.html
