### PR TITLE
movement controller: use default SIGINT handler

### DIFF
--- a/smt_movement_controller/src/smt_movement_controller_node.cpp
+++ b/smt_movement_controller/src/smt_movement_controller_node.cpp
@@ -3,7 +3,7 @@
 #include "smt_movement_controller/movement_controller.hpp"
 
 int main(int argc, char** argv) {
-    ros::init(argc, argv, "smt_movement_controller", ros::init_options::NoSigintHandler);
+    ros::init(argc, argv, "smt_movement_controller");
     ros::NodeHandle nodeHandle("~");
 
     smt::movement_controller::MovementController MovementController(nodeHandle);


### PR DESCRIPTION
this was a leftover from when we tried to have a custom SIGINT handler. because this is still here but our custom SIGINT handler isn't we currently don't have any SIGINT handler and the application isn't being terminated properly.