### PR TITLE
aligning the camera settings

### DIFF
--- a/smt_camera_controller/config/default.yaml
+++ b/smt_camera_controller/config/default.yaml
@@ -4,5 +4,5 @@ camera:
     height: 480
   fps: 10
 img_pub_topic:
-  topic: /image_raw
+  topic: /camera1/image_raw
   queue_size: 10


### PR DESCRIPTION
the simulated camera and the real camera had different topic names. The camera topic is now for both /camera1/image_raw/