### PR TITLE
gazebo: set `gaussianNoise` for IMU

### DIFF
--- a/smt_model_description/urdf/smt_model.gazebo
+++ b/smt_model_description/urdf/smt_model.gazebo
@@ -163,7 +163,7 @@
           <topicName>imu/data</topicName>
           <bodyName>IMU_1</bodyName>
           <updateRateHZ>100.0</updateRateHZ>
-          <gaussianNoise>0.0</gaussianNoise>
+          <gaussianNoise>0.5</gaussianNoise>
           <xyzOffset>0 0 0</xyzOffset>
           <rpyOffset>0 0 0</rpyOffset>
           <frameName>IMU_1</frameName>


### PR DESCRIPTION
the simulated IMU sends relatively bad data (e.g. the z acceleration isn't fixed at 9.81 but fluctuates wildely around that number). however, so far the covariance in the IMU data was always set to 0.0 which meant that the `ekf_localization_node` thought that the data was perfect and used it as the primary source, thus leading to wrong position estimates for the `odom` frame.
by setting the `gaussianNoise` it now sets a covariance and the localization algorithm gives the IMU data slightly less weight.

the number 0.5 was arrived at experimentally, it seems to give a good result: this allows mapping the whole map in gazebo without any noticeable drift.