### PR TITLE
suppress annoying 3rd party CMake warning

### DIFF
--- a/cmake/Findpigpio.cmake
+++ b/cmake/Findpigpio.cmake
@@ -2,7 +2,7 @@ include(ExternalProject)
 ExternalProject_Add(pigpio
   GIT_REPOSITORY    https://github.com/joan2937/pigpio.git
   GIT_TAG           v79
-  CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+  CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -Wno-dev
 )
 
 ExternalProject_Get_Property(pigpio INSTALL_DIR)

--- a/smt_camera_controller/cmake/Findraspicam.cmake
+++ b/smt_camera_controller/cmake/Findraspicam.cmake
@@ -1,7 +1,7 @@
 include(ExternalProject)
 ExternalProject_Add(raspicam
   GIT_REPOSITORY    https://github.com/cedricve/raspicam.git
-  CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+  CMAKE_ARGS        -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR> -Wno-dev
 )
 
 ExternalProject_Get_Property(raspicam INSTALL_DIR)


### PR DESCRIPTION
the warning occurs because these projects still use a CMake version 2.x specifier in their `CMakeLists.txt` which had a different policy than CMake 3.x which we're using. however, the warning being shown is only useful to the maintainers of these libraries and not to us, so we can follow the recommendation (printed by the warning!) to suppress it in this way.