### PR TITLE
fix handling of polygon in QR Code Finder

### DIFF
--- a/smt_qr_finder/CMakeLists.txt
+++ b/smt_qr_finder/CMakeLists.txt
@@ -146,8 +146,8 @@ include_directories(
 # add_executable(${PROJECT_NAME}_node src/smt_qr_finder_node.cpp)
 add_executable(
   ${PROJECT_NAME}_node
-        src/QRFinder.cpp
-        src/smt_qr_finder_node.cpp
+  src/QRFinder.cpp
+  src/smt_qr_finder_node.cpp
 )
 ## Rename C++ executable without prefix
 ## The above recommended prefix causes long target names, the following renames the
@@ -158,10 +158,9 @@ set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX ""
 
 ## Add cmake target dependencies of the executable
 ## same as for the library above
-# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
-target_link_directories(${PROJECT_NAME}_node PRIVATE BEFORE "${VCPKG_INSTALLED_DIR}/lib")
 target_link_libraries(${PROJECT_NAME}_node
   ${catkin_LIBRARIES}
   ${cv_bridge_LIBRARIES}

--- a/smt_qr_finder/include/smt_qr_finder/QRFinder.hpp
+++ b/smt_qr_finder/include/smt_qr_finder/QRFinder.hpp
@@ -1,6 +1,8 @@
 #ifndef SMT_QR_FINDER_QRFINDER_HPP
 #define SMT_QR_FINDER_QRFINDER_HPP
 
+#include <vector>
+
 #include <ros/ros.h>
 #include <sensor_msgs/Image.h>
 #include <geometry_msgs/Pose.h>
@@ -21,7 +23,7 @@ namespace smt {
         private:
             struct QRCode {
                 std::string text;
-                std::vector<cv::Point> const& polygon;
+                std::vector<cv::Point> const polygon;
             };
 
             ros::Subscriber imgSubscriber;
@@ -31,7 +33,7 @@ namespace smt {
             zbar::ImageScanner zbarScanner;
 
             std::vector<QRFinder::QRCode> searchForQrCodes(cv::Mat const& img);
-            geometry_msgs::Pose calculateQrCodePose(QRFinder::QRCode) const;
+            geometry_msgs::Pose calculateQrCodePose(QRFinder::QRCode const& qrCode) const;
         };
     }  // namespace qr_detector
 

--- a/smt_qr_finder/src/QRFinder.cpp
+++ b/smt_qr_finder/src/QRFinder.cpp
@@ -114,7 +114,7 @@ namespace smt {
             return qrCodes;
         }
 
-        geometry_msgs::Pose QRFinder::calculateQrCodePose(QRFinder::QRCode) const {
+        geometry_msgs::Pose QRFinder::calculateQrCodePose(QRFinder::QRCode const& qrCode) const {
             // TODO: 1. identify QR code size & orientation
             // TODO: 2. calculate vector from camera to QR code
             // TODO: 3. create pose (point + orientation) with this information

--- a/smt_qr_finder/src/smt_qr_finder_node.cpp
+++ b/smt_qr_finder/src/smt_qr_finder_node.cpp
@@ -3,10 +3,10 @@
 #include "smt_qr_finder/QRFinder.hpp"
 
 int main(int argc, char** argv) {
-    ros::init(argc, argv, "smt_qr_detector");
+    ros::init(argc, argv, "smt_qr_finder");
     ros::NodeHandle nodeHandle("~");
 
-    smt::qr_finder::QRFinder qrDetector(nodeHandle);
+    smt::qr_finder::QRFinder qrFinder(nodeHandle);
 
     ros::spin();
     return 0;


### PR DESCRIPTION
by accident the polygon was stored as a reference, however the original
variable went out of scope at the end of the loop, so the reference was
invalid afterwards.
it must of course not be stored as a reference but instead the struct
must own it.

also add the `vector` include. it was already there transiently, however
it's cleaner if we add it explicitly.
other minor fixes have been added as well.