### PR TITLE
add documentation on how to save the map

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ downloaded using [hector_geotiff](https://wiki.ros.org/hector_geotiff). If it is
 once the software is stopped / the robot powered down.
 Currently, the robot does not support loading a pre-made map and continue mapping in it.
 
+To save the map to [`smt_slam/maps`](smt_slam/maps) run:
+```bash
+rostopic pub /syscommand std_msgs/String -1 "data: 'savegeiff'"
+```
+
 ## Architecture
 
 ### Structure

--- a/smt_slam/maps/README.md
+++ b/smt_slam/maps/README.md
@@ -1,0 +1,3 @@
+# Saved Maps
+
+This folder contains the maps which you manually save. See [the main README](../../README.md) for further details.


### PR DESCRIPTION
the README in `smt_slam/maps` is there to ensure that the folder exists, otherwise saving the map fails.