### PR TITLE
implement QR-code pose calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ graph TD
 
   Camera[[Camera]] --> CameraController
   CameraController[Camera Controller] -->|"image<br/>message: <code>sensor_msgs/Image</code><br/>topic: <code>/camera1/image_raw</code>"| QRCodeFinder
-  QRCodeFinder[QR Code Finder] -->|"QR Code Pose<br/>message: <code>smt_qr_msgs/PoseWithString</code><br/>(= <code>geometry_msgs/Pose</code> + <code>string</code>)<br/>topic: <code>/qr_codes</code>"| QRCodeController
+  QRCodeFinder[QR Code Finder] -->|"QR Code Pose<br/>message: <code>smt_msgs/PoseWithString</code><br/>(= <code>geometry_msgs/Pose</code> + <code>string</code>)<br/>topic: <code>/qr_codes</code>"| QRCodeController
 
   QRCodeController[QR Code Controller] -->|"fire command<br/>service: <code>FireAt</code><br/>request:<code>std_msgs/Int32</code> (angle)"| GC
   GC[Gun Controller] -->|PWM signal| GS

--- a/smt_qr_finder/CMakeLists.txt
+++ b/smt_qr_finder/CMakeLists.txt
@@ -14,8 +14,12 @@ add_definitions(-Wall -Werror)
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   roscpp
+  geometry_msgs
   sensor_msgs
   cv_bridge
+  tf2
+  tf2_ros
+  tf2_geometry_msgs
   roslint
   smt_msgs
 )

--- a/smt_qr_finder/config/default.yaml
+++ b/smt_qr_finder/config/default.yaml
@@ -9,3 +9,7 @@ img_pub_topic:
 qr_code_topic:
   topic: /qr_codes
   queue_size: 10
+
+qr_code_pose_topic:
+  topic: /qr_code_pose
+  queue_size: 10

--- a/smt_qr_finder/include/smt_qr_finder/QRFinder.hpp
+++ b/smt_qr_finder/include/smt_qr_finder/QRFinder.hpp
@@ -6,6 +6,8 @@
 #include <ros/ros.h>
 #include <sensor_msgs/Image.h>
 #include <geometry_msgs/Pose.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_ros/transform_listener.h>
 
 #include <cv_bridge/cv_bridge.h>
 
@@ -29,11 +31,15 @@ namespace smt {
             ros::Subscriber imgSubscriber;
             ros::Publisher imgPublisher;
             ros::Publisher qrCodePublisher;
+            ros::Publisher qrCodePosePublisher;
+            tf2_ros::Buffer tfBuffer;
+            tf2_ros::TransformListener tfListener;
 
             zbar::ImageScanner zbarScanner;
 
             std::vector<QRFinder::QRCode> searchForQrCodes(cv::Mat const& img);
-            geometry_msgs::Pose calculateQrCodePose(QRFinder::QRCode const& qrCode) const;
+
+            geometry_msgs::Pose calculateQrCodePose(QRFinder::QRCode const& qrCode, int const width, int const height) const;
         };
     }  // namespace qr_detector
 

--- a/smt_qr_finder/package.xml
+++ b/smt_qr_finder/package.xml
@@ -51,9 +51,13 @@
   <buildtool_depend>catkin</buildtool_depend>
   <buildtool_depend>roslint</buildtool_depend>
   <depend>roscpp</depend>
+  <depend>geometry_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>cv_bridge</depend>
   <depend>zbar</depend>
+  <depend>tf2</depend>
+  <depend>tf2_ros</depend>
+  <depend>tf2_geometry_msgs</depend>
 
   <depend>smt_msgs</depend>
 

--- a/smt_qr_finder/src/QRFinder.cpp
+++ b/smt_qr_finder/src/QRFinder.cpp
@@ -3,19 +3,22 @@
 
 #include <ros/ros.h>
 #include <smt_msgs/PoseWithString.h>
+#include <geometry_msgs/Pose.h>
 
 #include "smt_qr_finder/QRFinder.hpp"
 
 
 namespace smt {
     namespace qr_finder {
-        QRFinder::QRFinder(ros::NodeHandle& nodeHandle) {
+        QRFinder::QRFinder(ros::NodeHandle& nodeHandle) : tfListener(tfBuffer) {
             std::string imgSubTopic;
             int imgSubQueueSize;
             std::string imgPubTopic;
             int imgPubQueueSize;
             std::string qrCodePubTopic;
             int qrCodePubQueueSize;
+            std::string qrCodePoseTopic;
+            int qrCodePoseQueueSize;
 
             if (!nodeHandle.getParam("img_sub_topic/topic", imgSubTopic)) {
                 ROS_ERROR("failed to load the `img_sub_topic/topic` parameter!");
@@ -46,6 +49,17 @@ namespace smt {
                 ROS_ERROR("failed to load the `gun_topic/queue_size` parameter!");
                 ros::requestShutdown();
             }
+
+            if (!nodeHandle.getParam("qr_code_pose_topic/topic", qrCodePoseTopic)) {
+                ROS_ERROR("failed to load the `gun_topic/topic` parameter!");
+                ros::requestShutdown();
+            }
+
+            if (!nodeHandle.getParam("qr_code_pose_topic/queue_size", qrCodePoseQueueSize)) {
+                ROS_ERROR("failed to load the `gun_topic/queue_size` parameter!");
+                ros::requestShutdown();
+            }
+
             imgSubscriber = nodeHandle.subscribe(imgSubTopic, imgSubQueueSize, &QRFinder::imgCallback, this);
             ROS_INFO("starting subscriber for %s with queue size %i", imgSubTopic.c_str(), imgSubQueueSize);
 
@@ -54,6 +68,9 @@ namespace smt {
 
             qrCodePublisher = nodeHandle.advertise<smt_msgs::PoseWithString>(qrCodePubTopic, qrCodePubQueueSize);
             ROS_INFO("starting publisher for %s with queue size %i", qrCodePubTopic.c_str(), qrCodePubQueueSize);
+
+            qrCodePosePublisher = nodeHandle.advertise<geometry_msgs::PoseStamped>(qrCodePoseTopic, qrCodePoseQueueSize);
+            ROS_INFO("starting publisher for %s with queue size %i", qrCodePoseTopic.c_str(), qrCodePoseQueueSize);
 
             zbarScanner.set_config(zbar::ZBAR_NONE, zbar::ZBAR_CFG_ENABLE, 1);
 
@@ -68,18 +85,24 @@ namespace smt {
 
             cv::Mat taggedImage = image.clone();
             for (auto const& qrCode : qrCodes) {
-                ROS_INFO_STREAM("found QR code: " << qrCode.text << " located at " << qrCode.polygon);
+                ROS_DEBUG_STREAM("found QR code: " << qrCode.text << " located at " << qrCode.polygon);
 
                 // tag QR code on image
-                cv::Scalar const COLOUR_GREEN = {0, 255, 0};
-                cv::polylines(taggedImage, qrCode.polygon, true, COLOUR_GREEN);
+                cv::Scalar const COLOUR_GREEN = { 0, 255, 0 };
+                cv::polylines(taggedImage, qrCode.polygon, true, COLOUR_GREEN, 2);
 
                 // calculate & publish QR code position
                 smt_msgs::PoseWithString positionMsg;
                 positionMsg.header.frame_id = "odom";
                 positionMsg.text = qrCode.text;
-                positionMsg.pose = this->calculateQrCodePose(qrCode);
+                positionMsg.pose = this->calculateQrCodePose(qrCode, image.cols, image.rows);
                 qrCodePublisher.publish(positionMsg);
+
+                // publish QR code pose
+                geometry_msgs::PoseStamped poseMsg;
+                poseMsg.header.frame_id = "odom";
+                poseMsg.pose = positionMsg.pose;
+                qrCodePosePublisher.publish(poseMsg);
             }
 
             // publish tagged image
@@ -101,21 +124,42 @@ namespace smt {
             for (auto s = zbarImg.symbol_begin(); s != zbarImg.symbol_end(); ++s)
             {
                 std::vector<cv::Point> polygon;
-                for(int i = 0; i < s->get_location_size(); i++) {
+                for (int i = 0; i < s->get_location_size(); i++) {
                     polygon.emplace_back(s->get_location_x(i), s->get_location_y(i));
                 }
-                qrCodes.push_back({s->get_data(), polygon});
+                qrCodes.push_back({ s->get_data(), polygon });
             }
 
             return qrCodes;
         }
 
-        geometry_msgs::Pose QRFinder::calculateQrCodePose(QRFinder::QRCode const& qrCode) const {
-            // TODO: 1. identify QR code size & orientation
-            // TODO: 2. calculate vector from camera to QR code
-            // TODO: 3. create pose (point + orientation) with this information
-            // TODO: 4. transform pose to `odom` frame using tf
-            return {};
+
+        geometry_msgs::Pose QRFinder::calculateQrCodePose(QRFinder::QRCode const& qrCode, int const width, int const height) const {
+            auto points = qrCode.polygon;
+            const auto distanceFactor = 93.09; //!< must be calculated one time with the cam. [pixel * meter] (measured distance * pixel)
+            const auto horizontalDistaneToQrCodeInMeter = distanceFactor / (points.at(0).y - points.at(1).y);
+            const auto qrCodeHeight = 0.145; //!< Height of QR-Code in m
+            const auto factorMPerPixel = qrCodeHeight / (points.at(0).x - points.at(3).x);
+
+            const auto midXAxisQrCode = (points.at(0).x - points.at(3).x) / 2 + points.at(3).x;
+            const auto midXAxisImg = width / 2;
+            const auto qrDistanceToMidAxisInMeter = (midXAxisImg - midXAxisQrCode) * factorMPerPixel;
+
+            geometry_msgs::Pose poseInCameraFrame;
+            poseInCameraFrame.position.x = horizontalDistaneToQrCodeInMeter;
+            poseInCameraFrame.position.y = qrDistanceToMidAxisInMeter;
+            poseInCameraFrame.position.z = 0.02;
+            poseInCameraFrame.orientation.x = 0.0;
+            poseInCameraFrame.orientation.y = 0.0;
+            poseInCameraFrame.orientation.z = 0.0;
+            poseInCameraFrame.orientation.w = 1.0;
+
+            auto const transformStamped = this->tfBuffer.lookupTransform("odom", "cam_1", ros::Time(0));
+
+            geometry_msgs::Pose poseInOdomFrame;
+            tf2::doTransform(poseInCameraFrame, poseInOdomFrame, transformStamped);
+
+            return poseInOdomFrame;
         }
 
     } // namesspace qr_detector


### PR DESCRIPTION
note that the orientation is currently left empty (or rather: set to the same as the camera, as if we'd always be facing exactly the QR code) which is of course wrong.
this might be added at some later point, but it's not really needed right now.