### PR TITLE
add gitignore for saved maps

### DIFF
--- a/smt_slam/maps/.gitignore
+++ b/smt_slam/maps/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md


### PR DESCRIPTION
otherwise the saved maps always show up in `git status` output and can accidentally be added to commits when using `git add .` or similar.