### PR TITLE
launch `smt_qr_controller`

### DIFF
--- a/smt_launch_common/launch/default.launch
+++ b/smt_launch_common/launch/default.launch
@@ -13,4 +13,5 @@
   </include>
 
   <include file="$(find smt_qr_finder)/launch/default.launch"/>
+  <include file="$(find smt_qr_controller)/launch/default.launch"/>
 </launch>


### PR DESCRIPTION
this is launched in both the simulation and the real robot, though the gun controller is only available in the real one.

this should've course have been part of the previous commit which added this node but i forgot it...